### PR TITLE
feat: ignore_cve / unignore_cve / list_cve_dispositions tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import * as audit from "./operations/audit.js";
 import * as clusters from "./operations/clusters.js";
 import * as identities from "./operations/identities.js";
 import * as images from "./operations/images.js";
+import * as cveDispositions from "./operations/cve-dispositions.js";
 import * as kubeobject from "./operations/kubeobject.js";
 import * as misconfigs from "./operations/misconfigs.js";
 import * as runtime from "./operations/runtime.js";
@@ -217,6 +218,26 @@ async function newServer(): Promise<Server> {
               name: "get_image_sbom",
               description: "Get the SBOM of a container image",
               inputSchema: zodToJsonSchema(images.GetImageSBOMSchema),
+            },
+            {
+              name: "ignore_cve",
+              description:
+                "Ignore a CVE for this account so it no longer appears in vulnerability reporting. Use for confirmed false positives, accepted risks, or won't-fix decisions. Do NOT use for remediated CVEs — those drop off automatically on the next scan.",
+              inputSchema: zodToJsonSchema(cveDispositions.ignoreCveSchema),
+            },
+            {
+              name: "unignore_cve",
+              description:
+                "Remove an account-wide CVE disposition, restoring the CVE to vulnerability reporting.",
+              inputSchema: zodToJsonSchema(cveDispositions.unignoreCveSchema),
+            },
+            {
+              name: "list_cve_dispositions",
+              description:
+                "List active CVE dispositions (ignored / false positive) for this account, with reason and author.",
+              inputSchema: zodToJsonSchema(
+                cveDispositions.listCveDispositionsSchema
+              ),
             },
           ]
         : []),
@@ -811,6 +832,47 @@ For complete schema: call radql_get_type_metadata with target data_type`,
               request.params.arguments
             );
             const response = await images.getImageSBOM(client, args.digest);
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(response, null, 2) },
+              ],
+            };
+          }
+          case "ignore_cve": {
+            const args = cveDispositions.ignoreCveSchema.parse(
+              request.params.arguments
+            );
+            const response = await cveDispositions.ignoreCve(
+              client,
+              args.cve_name,
+              args.disposition,
+              args.reason
+            );
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(response, null, 2) },
+              ],
+            };
+          }
+          case "unignore_cve": {
+            const args = cveDispositions.unignoreCveSchema.parse(
+              request.params.arguments
+            );
+            const response = await cveDispositions.unignoreCve(
+              client,
+              args.cve_name
+            );
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(response, null, 2) },
+              ],
+            };
+          }
+          case "list_cve_dispositions": {
+            cveDispositions.listCveDispositionsSchema.parse(
+              request.params.arguments
+            );
+            const response = await cveDispositions.listCveDispositions(client);
             return {
               content: [
                 { type: "text", text: JSON.stringify(response, null, 2) },

--- a/src/operations/cve-dispositions.ts
+++ b/src/operations/cve-dispositions.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { RadSecurityClient } from "../client.js";
+
+// Disposition kinds mirror the api-imagescan backend. "remediated" is
+// intentionally absent: a real fix drops out on the next scan, and suppressing
+// it would mask a regression.
+export const dispositionKinds = [
+  "false_positive",
+  "accepted_risk",
+  "wont_fix",
+] as const;
+
+// Input schemas
+export const ignoreCveSchema = z.object({
+  cve_name: z.string().describe("CVE ID to ignore, e.g. CVE-2024-1234"),
+  disposition: z
+    .enum(dispositionKinds)
+    .describe(
+      "Why the CVE is being ignored: false_positive, accepted_risk, or wont_fix"
+    ),
+  reason: z
+    .string()
+    .optional()
+    .describe("Free-text justification, recorded for audit (recommended)"),
+});
+
+export const unignoreCveSchema = z.object({
+  cve_name: z
+    .string()
+    .describe("CVE ID to un-ignore (restore to reporting), e.g. CVE-2024-1234"),
+});
+
+export const listCveDispositionsSchema = z.object({});
+
+// Main functions
+export async function ignoreCve(
+  client: RadSecurityClient,
+  cve_name: string,
+  disposition: string,
+  reason: string = ""
+): Promise<any> {
+  return client.makeRequest(
+    `/accounts/${client.getAccountId()}/inventory_cves/dispositions`,
+    {},
+    { method: "POST", body: { cve_name, disposition, reason } }
+  );
+}
+
+export async function listCveDispositions(
+  client: RadSecurityClient
+): Promise<any> {
+  return client.makeRequest(
+    `/accounts/${client.getAccountId()}/inventory_cves/dispositions`
+  );
+}
+
+export async function unignoreCve(
+  client: RadSecurityClient,
+  cve_name: string
+): Promise<any> {
+  const target = cve_name.trim().toUpperCase();
+  const active = await listCveDispositions(client);
+  const match = (active || []).find(
+    (d: any) =>
+      (d.cve_name || "").toUpperCase() === target &&
+      !d.cluster_id &&
+      !d.image_digest
+  );
+  if (!match) {
+    throw new Error(
+      `No active account-wide disposition found for ${target}`
+    );
+  }
+  await client.makeRequest(
+    `/accounts/${client.getAccountId()}/inventory_cves/dispositions/${match.id}`,
+    {},
+    { method: "DELETE" }
+  );
+  return { removed: match.id, cve_name: target };
+}


### PR DESCRIPTION
## Why

Pairs with ksoc-private/api-imagescan#387, which adds the CVE disposition (ignore / false positive) write path. This exposes it to RADBot and automations so a workflow can read a decision (e.g. from a BusinessMap card) and actually suppress the CVE in RAD.

## What

Three tools under the `images` toolkit, wrapping `/accounts/{account_id}/inventory_cves/dispositions`:

- **`ignore_cve`** — `{cve_name, disposition, reason?}` where disposition ∈ `false_positive | accepted_risk | wont_fix`. The description steers the model away from using it for remediated CVEs (those drop off on the next scan).
- **`unignore_cve`** — `{cve_name}`; resolves the CVE to its active account-wide disposition and deletes it, so callers don't need to track disposition IDs.
- **`list_cve_dispositions`** — active dispositions with reason + author.

Follows the existing `update_security_finding_status` pattern (thin wrappers over `client.makeRequest`).

## Verification

`tsc` type-check and `eslint` clean; pre-commit hooks pass. (No runtime test suite in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)