### PR TITLE
ci: publish to npm via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -29,48 +29,3 @@ jobs:
 
       - name: Build
         run: npm run build
-
-  publish-dirty:
-    needs: quality
-    runs-on: ubuntu-latest
-    environment: dirty-release
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Generate dirty version
-        id: version
-        run: |
-          # Get version from git describe (e.g., v0.0.24-5-gabcdef or v0.0.24)
-          GIT_VERSION=$(git describe --always --tags)
-          # Remove 'v' prefix if present
-          VERSION=${GIT_VERSION#v}
-          # Replace hyphens in prerelease part with dots for valid semver
-          # e.g., 0.0.27-9-gc010b1d -> 0.0.27-9.gc010b1d
-          VERSION=$(echo "$VERSION" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)-\([0-9]*\)-\(g[0-9a-f]*\)$/\1-\2.\3/')
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Generate version file
-        run: |
-          echo "export const VERSION = \"${{ steps.version.outputs.VERSION }}\";" > src/version.ts
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Update version in package.json
-        run: npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish to NPM with dirty tag
-        run: npm publish --access public --tag dirty
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,43 +1,78 @@
 name: Publish to NPM
 
+# npm allows only ONE Trusted Publisher (one workflow file) per package, so both
+# the tag publish (`latest`) and the main-branch publish (`dirty`) live here.
+#
+# Triggers on tag *pushes* rather than `release: created` — pushing a `v*` tag is
+# enough, creating a GitHub Release is not required.
 on:
-  release:
-    types: [created]
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+
+permissions:
+  contents: read
+  id-token: write # required for npm Trusted Publishing (OIDC)
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history so `git describe` can resolve the dirty version
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Extract version from tag
-        id: get_version
+      - name: Upgrade npm
+        run: npm install -g npm@latest # Trusted Publishing needs npm >= 11.5.1
+
+      - name: Resolve version and dist-tag
+        id: version
         run: |
-          # Extract version from git tag (removing v prefix if present)
-          TAG_VERSION=${GITHUB_REF#refs/tags/}
-          TAG_VERSION=${TAG_VERSION#v}
-          echo "VERSION=$TAG_VERSION" >> $GITHUB_OUTPUT
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            # Version comes from the git tag (e.g. v0.0.30 -> 0.0.30)
+            VERSION=${GITHUB_REF#refs/tags/}
+            VERSION=${VERSION#v}
+            DIST_TAG=latest
+          else
+            # Version comes from git describe (e.g. v0.0.30-9-gc010b1d)
+            VERSION=$(git describe --always --tags)
+            VERSION=${VERSION#v}
+            # Hyphens in the prerelease part must become dots for valid semver
+            # e.g. 0.0.30-9-gc010b1d -> 0.0.30-9.gc010b1d
+            VERSION=$(echo "$VERSION" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\)-\([0-9]*\)-\(g[0-9a-f]*\)$/\1-\2.\3/')
+            DIST_TAG=dirty
+            if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              # HEAD sits exactly on a tag, so the tag push already publishes this
+              # version as `latest` — republishing it as `dirty` would 403.
+              echo "SKIP=true" >> $GITHUB_OUTPUT
+            fi
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "DIST_TAG=$DIST_TAG" >> $GITHUB_OUTPUT
 
       - name: Generate version file
         run: |
-          echo "export const VERSION = \"${{ steps.get_version.outputs.VERSION }}\";" > src/version.ts
+          echo "export const VERSION = \"${{ steps.version.outputs.VERSION }}\";" > src/version.ts
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Update version in package.json
-        run: npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version
+        run: npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
+
+      - name: Type check
+        run: npm run type-check
 
       - name: Build
         run: npm run build
 
       - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No NODE_AUTH_TOKEN: npm authenticates via OIDC (Trusted Publishing)
+        if: steps.version.outputs.SKIP != 'true'
+        run: npm publish --access public --tag ${{ steps.version.outputs.DIST_TAG }}


### PR DESCRIPTION
## Summary

Nothing has reached npm since **v0.0.27 (2026-01-29)** because of two separate failures:

- **The org-level `NPM_TOKEN` expired on 2026-02-03**, when npm capped all long-lived granular tokens. Every `publish-dirty` run since fails with `E404` on `PUT /@rad-security%2fmcp-server` — npm returns 404, not 403, for invalid credentials, so the package "not found" message is misleading.
- **`publish.yml` triggered on `release: created`**, but `v0.0.28`, `v0.0.29` and `v0.0.30` were pushed as bare tags with no GitHub Release, so the publish workflow never ran at all for them.

This consolidates both publish paths into `publish.yml` and authenticates via OIDC instead of a token, so there is nothing left to expire. npm permits only one trusted-publisher workflow per package, hence merging the `publish-dirty` job out of `ci.yml`.

- Trigger on **tag push** (`v*` → `latest`) and **main push** (`git describe` → `dirty`) — pushing a tag is now enough, no GitHub Release required
- Add `id-token: write` and upgrade npm, as Trusted Publishing needs npm >= 11.5.1
- Skip the `dirty` publish when HEAD sits exactly on a tag, which would otherwise 403 against the tag's own publish
- Bump `checkout`/`setup-node` to v7, clearing the Node 20 deprecation warnings
- Switch `npm install` → `npm ci` (lockfile verified in sync)

## Before merging

Trusted Publishing must be configured at [npmjs.com/package/@rad-security/mcp-server/access](https://www.npmjs.com/package/@rad-security/mcp-server/access) first, or the run fails on OIDC instead of on the token:

| Field | Value |
|---|---|
| Organization or user | `rad-security` |
| Repository | `mcp-server` |
| Workflow filename | `publish.yml` |
| Environment | *(leave blank)* |
| Allowed actions | `npm publish` |

Environment is blank because `environment: dirty-release` was dropped from the job (it had no protection rules) so a single config covers both triggers.

## After merging

- **`v0.0.30` will not auto-publish** — the tag already exists, so no push event fires. Re-push the tag or cut `v0.0.31`.
- The `NPM_TOKEN` org secret can be deleted. It is an org-level secret, so any other repo publishing to npm is likely broken too.
- Public repo + OIDC means npm now generates provenance attestations automatically.

## Test plan

- Both workflow files validated as parsing YAML
- Version resolution simulated across all three cases: tag push → `0.0.31`/`latest`; main push with HEAD on a tag → `SKIP=true`; main push 2 commits past a tag → `0.0.30-2.gd0de4c1`/`dirty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)