### PR TITLE
feat: scope ignore_cve to cluster / image / image-repo+name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -716,12 +716,7 @@ For complete schema: call radql_get_type_metadata with target data_type`,
             const args = cveDispositions.ignoreCveSchema.parse(
               request.params.arguments
             );
-            const response = await cveDispositions.ignoreCve(
-              client,
-              args.cve_name,
-              args.disposition,
-              args.reason
-            );
+            const response = await cveDispositions.ignoreCve(client, args);
             return {
               content: [
                 { type: "text", text: JSON.stringify(response, null, 2) },

--- a/src/operations/cve-dispositions.ts
+++ b/src/operations/cve-dispositions.ts
@@ -22,6 +22,26 @@ export const ignoreCveSchema = z.object({
     .string()
     .optional()
     .describe("Free-text justification, recorded for audit (recommended)"),
+  // Optional scope. Provide at most one of: cluster_id; image_digest;
+  // (image_repo + image_name together). Omit all for an account-wide rule.
+  cluster_id: z
+    .string()
+    .optional()
+    .describe("Scope: ignore the CVE only in this cluster (cluster UUID)"),
+  image_digest: z
+    .string()
+    .optional()
+    .describe("Scope: ignore the CVE on this exact image build (image digest)"),
+  image_repo: z
+    .string()
+    .optional()
+    .describe(
+      "Scope: ignore across all builds of an image — repo, e.g. 'docker.io/library/' (set with image_name)"
+    ),
+  image_name: z
+    .string()
+    .optional()
+    .describe("Scope: image name, e.g. 'redis' (set with image_repo)"),
 });
 
 export const unignoreCveSchema = z.object({
@@ -35,14 +55,31 @@ export const listCveDispositionsSchema = z.object({});
 // Main functions
 export async function ignoreCve(
   client: RadSecurityClient,
-  cve_name: string,
-  disposition: string,
-  reason: string = ""
+  input: {
+    cve_name: string;
+    disposition: string;
+    reason?: string;
+    cluster_id?: string;
+    image_digest?: string;
+    image_repo?: string;
+    image_name?: string;
+  }
 ): Promise<any> {
   return client.makeRequest(
     `/accounts/${client.getAccountId()}/inventory_cves/dispositions`,
     {},
-    { method: "POST", body: { cve_name, disposition, reason } }
+    {
+      method: "POST",
+      body: {
+        cve_name: input.cve_name,
+        disposition: input.disposition,
+        reason: input.reason ?? "",
+        cluster_id: input.cluster_id,
+        image_digest: input.image_digest,
+        image_repo: input.image_repo,
+        image_name: input.image_name,
+      },
+    }
   );
 }
 


### PR DESCRIPTION
## Summary

Pairs with ksoc-private/api-imagescan#388. `ignore_cve` gains optional scope fields so RADBot/automations can ignore a CVE for one cluster, one image build (digest), or all builds of an image (repo+name) — not just account-wide.

- `cluster_id` — ignore only in that cluster
- `image_digest` — ignore one exact build
- `image_repo` + `image_name` — ignore across all builds of an image

Omitting all keeps account-wide behavior. `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
