### PR TITLE
ci: multi-arch image + v-prefixed version tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,7 +57,10 @@ jobs:
           images: ${{ env.IMAGE }}
           tags: |
             type=sha,prefix=sha-,format=short
-            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+
+      - name: Set up QEMU (for cross-arch builds)
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -66,6 +69,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ steps.version.outputs.value }}


### PR DESCRIPTION
## Summary

Fixes the `ErrImagePull` on the deployed mcp-server and aligns the image tag with the org convention.

- **Multi-arch build**: add `docker/setup-qemu-action` and `platforms: linux/amd64,linux/arm64` so the workflow publishes a manifest list. The previous amd64-only image failed to pull on arm64/Graviton nodes:
  > `no match for platform in manifest … ErrImagePull`
- **v-prefixed tags**: released images are now tagged `v<version>` (e.g. `v0.0.34`) via `type=semver,pattern=v{{version}}`, matching the `v0.1.x` convention used by the other backend images. `sha-<short>` tags on `main` pushes are unchanged.

## Follow-up

The already-published `0.0.34` image is amd64-only and un-prefixed. After this merges, (re)publish the `v0.0.34` release tag so a **multi-arch `v0.0.34`** image exists in ECR, then the ksoc-v2 overlays (separate PR) pull it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)