### PR TITLE
fix: exclude filter no longer re-enables disabled-by-default toolkits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,19 +117,22 @@ function isToolkitEnabled(
   toolkitType: ToolkitType,
   filters: { include?: ToolkitType[]; exclude?: ToolkitType[] }
 ): boolean {
-  // If include list is specified, only those toolkits are enabled
+  // If include list is specified, only those toolkits are enabled (an explicit
+  // include can opt in to a disabled-by-default toolkit).
   if (filters.include && filters.include.length > 0) {
     return filters.include.includes(toolkitType);
+  }
+
+  // Toolkits disabled by default require explicit inclusion — they must never
+  // be turned on by an exclude filter (which would otherwise re-enable them)
+  // or by the default-on case below.
+  if (DISABLED_BY_DEFAULT_TOOLKITS.includes(toolkitType)) {
+    return false;
   }
 
   // If exclude list is specified, all except those are enabled
   if (filters.exclude && filters.exclude.length > 0) {
     return !filters.exclude.includes(toolkitType);
-  }
-
-  // Toolkits disabled by default require explicit inclusion
-  if (DISABLED_BY_DEFAULT_TOOLKITS.includes(toolkitType)) {
-    return false;
   }
 
   // By default, all other toolkits are enabled


### PR DESCRIPTION
## Summary

Found while verifying the new `X-Rad-Exclude-Toolkits` header on prod: excluding toolkits **re-enabled `custom_workflows`** (the workflow-authoring write tools), which is disabled by default. So *narrowing* an agent's scope accidentally *exposed* write tools — the opposite of least privilege.

**Cause:** `isToolkitEnabled()` checked `DISABLED_BY_DEFAULT_TOOLKITS` *after* the exclude branch, so any exclude filter returned before the guard ran. Pre-existing in the env `EXCLUDE_TOOLKITS` path too; the header just surfaced it.

**Fix:** move the disabled-by-default guard above the exclude branch (still below `include`, so an explicit `include: custom_workflows` can still opt in).

## Verified (local)

| Request | Before | After |
|---|---|---|
| no filter | 45, no custom_workflows | 45, no custom_workflows |
| `exclude: workflows,radql` | 36, **custom_workflows present** ❌ | 33, none ✅ |
| `exclude: audit` | would add custom_workflows ❌ | 44, none ✅ |
| `include: custom_workflows` | 3 | 3 (opt-in still works) ✅ |

Type-check, lint, build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)