### PR TITLE
fix(ci): give the scan container ECR credentials

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,6 +98,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # The scan action runs inside a container whose $HOME is /github/home, so
+      # the ECR credentials amazon-ecr-login wrote to the runner's ~/.docker are
+      # invisible to it and pulling the pushed image fails with "no basic auth
+      # credentials". Copy them across — same as plugin-ksoc-sbom's marketplace
+      # workflow, which likewise scans an image in a private ECR. Not needed on
+      # pull requests, which scan a locally-loaded image.
+      - name: Provide ECR auth to the scan container
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "$RUNNER_TEMP/_github_home/.docker"
+          cp ~/.docker/config.json "$RUNNER_TEMP/_github_home/.docker/config.json"
+
       # Scan with RAD Security (dogfooding the same action plugin-ksoc-sbom
       # uses). Fails the run on high/critical findings, on a severity regression
       # against deployed instances, or on an end-of-life base image — so a bad


### PR DESCRIPTION
## Summary

Fixes the scan failure on `main` / tag builds (e.g. the `v0.0.39` run).

The image reference was correct — `…/rad-security/mcp-server:sha-75a8dbb` — but the pull failed:

```
ERROR failed to catalog: errors occurred attempting to resolve
  '…/rad-security/mcp-server:sha-75a8dbb':
  - docker: pull failed: Head "…/manifests/sha-75a8dbb": no basic auth credentials
```

**Cause:** the scan action runs inside a container whose `$HOME` is `/github/home`. The ECR credentials `amazon-ecr-login` writes to the *runner's* `~/.docker/config.json` aren't visible inside it, so the pull is unauthenticated.

**Fix:** copy the docker config into `$RUNNER_TEMP/_github_home/.docker`, which is mounted as the container's home. This is the same `Provide ECR auth to scan container` step `plugin-ksoc-sbom` uses in its **marketplace** workflow (private ECR). I modeled the original on its **public-ECR** workflow, which needs no auth — hence the gap.

Skipped on pull requests, which scan a locally-loaded image and never touch ECR (that path already passes).

## Impact

The image itself **was built and pushed successfully** — only the scan step failed, so `v0.0.39` is in ECR and nothing is blocked. This restores the scan gate on published images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)