### PR TITLE
feat(knowledge-base): get_knowledge_base_document_content tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -476,6 +476,15 @@ async function newServer(
                 knowledgeBase.StructuredQueryDocumentSchema
               ),
             },
+            {
+              name: "get_knowledge_base_document_content",
+              annotations: { title: "Get Knowledge Base Document Content", readOnlyHint: true },
+              description:
+                "Get the FULL text content of a knowledge base document (extracted text for PDF/DOCX, the raw file for markdown/plaintext/CSV). Use this to read or analyze a whole document rather than the excerpts search_knowledge_base returns. Find document IDs via list_knowledge_base_documents or search_knowledge_base results",
+              inputSchema: zodToJsonSchema(
+                knowledgeBase.GetDocumentContentSchema
+              ),
+            },
           ]
         : []),
       // RadQL tools
@@ -1209,6 +1218,20 @@ For complete schema: call radql_get_type_metadata with target data_type`,
               client,
               args.document_id,
               args.query
+            );
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(response, null, 2) },
+              ],
+            };
+          }
+          case "get_knowledge_base_document_content": {
+            const args = knowledgeBase.GetDocumentContentSchema.parse(
+              request.params.arguments
+            );
+            const response = await knowledgeBase.getDocumentContent(
+              client,
+              args.document_id
             );
             return {
               content: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -485,6 +485,15 @@ async function newServer(
                 knowledgeBase.GetDocumentContentSchema
               ),
             },
+            {
+              name: "get_knowledge_base_document_download_url",
+              annotations: { title: "Get Knowledge Base Document Download URL", readOnlyHint: true },
+              description:
+                "Get a time-limited download URL for the ORIGINAL document file (any format, including PDF/DOCX binaries). Use when you need the original file itself — e.g. to fetch it into a sandbox for structural parsing (tables, layout), or when get_knowledge_base_document_content reports no text available. For reading text, prefer get_knowledge_base_document_content",
+              inputSchema: zodToJsonSchema(
+                knowledgeBase.GetDocumentDownloadUrlSchema
+              ),
+            },
           ]
         : []),
       // RadQL tools
@@ -1230,6 +1239,20 @@ For complete schema: call radql_get_type_metadata with target data_type`,
               request.params.arguments
             );
             const response = await knowledgeBase.getDocumentContent(
+              client,
+              args.document_id
+            );
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(response, null, 2) },
+              ],
+            };
+          }
+          case "get_knowledge_base_document_download_url": {
+            const args = knowledgeBase.GetDocumentDownloadUrlSchema.parse(
+              request.params.arguments
+            );
+            const response = await knowledgeBase.getDocumentDownloadUrl(
               client,
               args.document_id
             );

--- a/src/operations/knowledge-base.ts
+++ b/src/operations/knowledge-base.ts
@@ -25,6 +25,10 @@ export const GetDocumentContentSchema = z.object({
   document_id: z.string().describe("The ID of the document to fetch. Find document IDs via list_knowledge_base_documents or in search_knowledge_base results."),
 });
 
+export const GetDocumentDownloadUrlSchema = z.object({
+  document_id: z.string().describe("The ID of the document to get a download URL for. Find document IDs via list_knowledge_base_documents or in search_knowledge_base results."),
+});
+
 export const StructuredQueryDocumentSchema = z.object({
   document_id: z.string().describe("The ID of the CSV document to query. Use list_knowledge_base_documents with filters='file_type:csv' to find CSV document IDs. Document IDs are also available in search_knowledge_base results. This will fail if the document is not a CSV file."),
   query: z.string().describe("Natural language question to execute against the CSV document. The system will analyze the CSV structure and generate the appropriate query (e.g., 'Show me all rows where severity is critical', 'Count the number of vulnerabilities by type', 'Show me the owner of asset IKM99832')."),
@@ -138,6 +142,21 @@ export async function getDocumentContent(
 
   return client.makeRequest(
     `/tenants/${tenantId}/accounts/${client.getAccountId()}/knowledge_base/documents/${documentId}/content`,
+    {},
+    {
+      method: "GET",
+    }
+  );
+}
+
+export async function getDocumentDownloadUrl(
+  client: RadSecurityClient,
+  documentId: string,
+): Promise<any> {
+  const tenantId = await client.getTenantId();
+
+  return client.makeRequest(
+    `/tenants/${tenantId}/accounts/${client.getAccountId()}/knowledge_base/documents/${documentId}/download`,
     {},
     {
       method: "GET",

--- a/src/operations/knowledge-base.ts
+++ b/src/operations/knowledge-base.ts
@@ -21,6 +21,10 @@ export const ListDocumentsSchema = z.object({
   filters: z.string().optional().describe("Filter documents by collections, file_type (pdf, markdown, plaintext, csv), or status (ready, processing, error) (e.g., 'collections:vuln;security,file_type:pdf,status:ready'). Multiple filters can be combined with commas."),
 });
 
+export const GetDocumentContentSchema = z.object({
+  document_id: z.string().describe("The ID of the document to fetch. Find document IDs via list_knowledge_base_documents or in search_knowledge_base results."),
+});
+
 export const StructuredQueryDocumentSchema = z.object({
   document_id: z.string().describe("The ID of the CSV document to query. Use list_knowledge_base_documents with filters='file_type:csv' to find CSV document IDs. Document IDs are also available in search_knowledge_base results. This will fail if the document is not a CSV file."),
   query: z.string().describe("Natural language question to execute against the CSV document. The system will analyze the CSV structure and generate the appropriate query (e.g., 'Show me all rows where severity is critical', 'Count the number of vulnerabilities by type', 'Show me the owner of asset IKM99832')."),
@@ -120,6 +124,21 @@ export async function listDocuments(
   return client.makeRequest(
     `/tenants/${tenantId}/accounts/${client.getAccountId()}/knowledge_base/documents`,
     params,
+    {
+      method: "GET",
+    }
+  );
+}
+
+export async function getDocumentContent(
+  client: RadSecurityClient,
+  documentId: string,
+): Promise<any> {
+  const tenantId = await client.getTenantId();
+
+  return client.makeRequest(
+    `/tenants/${tenantId}/accounts/${client.getAccountId()}/knowledge_base/documents/${documentId}/content`,
+    {},
     {
       method: "GET",
     }


### PR DESCRIPTION
## What

New read-only MCP tool `get_knowledge_base_document_content(document_id)` returning a document's FULL text via the backend's new content endpoint (rad-security/rad#424): extracted text for PDF/DOCX, the raw file for markdown/plaintext/CSV.

## Why

`search_knowledge_base` returns scored excerpts; no operation returned a whole document. RAD Bot V4 is sandbox-native — a large tool result is automatically offloaded to a sandbox file the agent can read/grep/analyze — so this tool lets agents work with complete documents instead of snippets. Companion wiring in ksoc-private/ai-agents#274.

Depends on rad-security/rad#424 being deployed (returns 404 until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKzcXrXCeq7zDhxVebewR4