### PR TITLE
Enable all toolkits by default, add dashboard writes, fold automations into workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -114,6 +114,20 @@ jobs:
           rad_account_ids: 2IAtTppYqpVGxSdkBWW5n7zYzVU
           rad_fail_on_regression: high
           rad_fail_on_eol: "true"
+          # CVE-2026-58043 (High, published 2026-07-30): the Node.js Permission Model can
+          # over-grant filesystem access. NOT REACHABLE HERE — the permission model is opt-in and
+          # this image never enables it (ENTRYPOINT is plain `node dist/index.js`; no --permission
+          # or --allow-fs-* anywhere in the repo). CVSS is also AV:L/AC:H/PR:L, so it needs local
+          # code execution inside the container to even attempt.
+          #
+          # It is not fixable by upgrading: 22.23.2 is the newest Node 22 (2026-07-28, two days
+          # BEFORE the advisory) and no 22.x patch has shipped. `node:22-alpine` is a floating tag,
+          # so a patched release is picked up automatically on the next build.
+          #
+          # REMOVE this entry once Node 22.23.3+ is out — leaving it would silently suppress a
+          # future finding. Re-check on the next dependency bump.
+          ignore_cves: |
+            CVE-2026-58043
 
       - name: Upload RAD report
         if: success() || failure()

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ By default a connection gets every toolkit. To give an agent a smaller set — l
 | `X-Rad-Exclude-Toolkits: workflows` | every toolkit except these |
 | `X-Rad-Readonly: true` | only read-only tools (drops the write tools) |
 
-Toolkits: `containers`, `clusters`, `audit`, `images`, `kubeobject`, `runtime`, `findings`, `inbox`, `workflows`, `knowledge_base`, `radql`, `dashboards`, `integrations` (plus `custom_workflows`, off by default).
+Toolkits: `containers`, `clusters`, `audit`, `images`, `kubeobject`, `runtime`, `findings`, `inbox`, `workflows`, `knowledge_base`, `radql`, `dashboards`, `integrations`. All are enabled by default — narrow with the headers above, and use `X-Rad-Readonly` when you want to exclude every write tool.
 
 Example — a read-only findings/images agent (any client that supports headers; Cursor shown):
 
@@ -213,7 +213,7 @@ claude mcp add --transport http rad-security https://api.rad.security/mcp/ \
 
 ## Features
 
-All tools require authentication and an account in RAD Security. The hosted endpoint exposes every toolkit below except `custom_workflows` (workflow authoring), which is off by default.
+All tools require authentication and an account in RAD Security. The hosted endpoint exposes every toolkit below by default; scope a client down with `X-Rad-Toolkits` / `X-Rad-Exclude-Toolkits`, or drop all write tools with `X-Rad-Readonly: true`.
 
 - Account Inventory
   - List clusters and their details
@@ -247,11 +247,14 @@ All tools require authentication and an account in RAD Security. The hosted endp
   - List inbox items and their details
   - Mark an inbox item as a false positive
 
-- Workflows
-  - List workflows, runs and schedules
-  - Get workflow and workflow run details
-  - Run a workflow
-  - Create and update custom workflows and schedules (via `custom_workflows`, disabled by default)
+- Automations (`workflows`)
+  - List automations, runs and schedules
+  - Get automation and run details
+  - Run an automation
+  - Create and update automations, and add cron schedules
+
+  > "Automation" is the product name users see; "workflow" is the underlying Windmill object the
+  > API and tool names use. They are the same thing.
 
 - Knowledge Base
   - Search the knowledge base
@@ -261,6 +264,8 @@ All tools require authentication and an account in RAD Security. The hosted endp
 - Dashboards
   - List dashboards and get their details
   - List and get dashboard and widget templates
+  - Create a dashboard, and update one in place (omitted fields are left unchanged, so a small
+    edit does not require resending the whole dashboard)
 
 - Integrations
   - List external integrations
@@ -332,7 +337,7 @@ Control which toolkits a self-hosted server exposes:
 - `INCLUDE_TOOLKITS`: comma-separated list of toolkits to include (only these are enabled).
 - `EXCLUDE_TOOLKITS`: comma-separated list of toolkits to exclude (all others are enabled). Ignored if `INCLUDE_TOOLKITS` is set.
 
-Available toolkits: `containers`, `clusters`, `audit`, `images`, `kubeobject`, `runtime`, `findings`, `inbox`, `workflows`, `custom_workflows` (disabled by default), `knowledge_base`, `radql`, `dashboards`, `integrations`.
+Available toolkits: `containers`, `clusters`, `audit`, `images`, `kubeobject`, `runtime`, `findings`, `inbox`, `workflows`, `knowledge_base`, `radql`, `dashboards`, `integrations`. All are enabled by default.
 
 ```bash
 # Only the workflows toolkit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1887,9 +1887,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,6 @@ type ToolkitType =
   | "findings"
   | "inbox"
   | "workflows"
-  | "custom_workflows"
   | "knowledge_base"
   | "radql"
   | "dashboards"
@@ -109,25 +108,19 @@ function toolkitFiltersForRequest(req: express.Request): ToolkitFilters {
   return { ...parseToolkitFilters(), readonly };
 }
 
-// Toolkits that are disabled by default and must be explicitly included
-const DISABLED_BY_DEFAULT_TOOLKITS: ToolkitType[] = ["custom_workflows"];
-
-// Check if a toolkit type should be enabled
+// Check if a toolkit type should be enabled.
+//
+// Every toolkit is enabled by default; narrowing is opt-in through the include/exclude filters
+// (INCLUDE_TOOLKITS / EXCLUDE_TOOLKITS, or the X-Rad-Toolkits / X-Rad-Exclude-Toolkits headers).
+// Write safety is `readonly`'s job, not the toolkit list's: it is enforced per tool, so a caller
+// that wants read-only access gets it no matter which toolkits are loaded.
 function isToolkitEnabled(
   toolkitType: ToolkitType,
   filters: { include?: ToolkitType[]; exclude?: ToolkitType[] }
 ): boolean {
-  // If include list is specified, only those toolkits are enabled (an explicit
-  // include can opt in to a disabled-by-default toolkit).
+  // If include list is specified, only those toolkits are enabled
   if (filters.include && filters.include.length > 0) {
     return filters.include.includes(toolkitType);
-  }
-
-  // Toolkits disabled by default require explicit inclusion — they must never
-  // be turned on by an exclude filter (which would otherwise re-enable them)
-  // or by the default-on case below.
-  if (DISABLED_BY_DEFAULT_TOOLKITS.includes(toolkitType)) {
-    return false;
   }
 
   // If exclude list is specified, all except those are enabled
@@ -135,7 +128,7 @@ function isToolkitEnabled(
     return !filters.exclude.includes(toolkitType);
   }
 
-  // By default, all other toolkits are enabled
+  // By default, every toolkit is enabled
   return true;
 }
 
@@ -409,32 +402,37 @@ async function newServer(
             },
           ]
         : []),
-      // Custom Workflows tools (disabled by default, enable via INCLUDE_TOOLKITS=custom_workflows)
-      ...(isToolkitEnabled("custom_workflows", toolkitFilters)
+      // Automation authoring tools. These live in the `workflows` toolkit alongside the read
+      // tools above — an agent that can inspect automations can also build them.
+      //
+      // The tool NAMES are a public contract: the web-app's automations builder watches for
+      // `create_custom_workflow` / `update_custom_workflow` by name to know a workflow was
+      // written, and onboarding provisioning does the same. Do not rename them.
+      ...(isToolkitEnabled("workflows", toolkitFilters)
         ? [
             {
               name: "create_custom_workflow",
-              annotations: { title: "Create Custom Workflow", readOnlyHint: false, destructiveHint: false },
+              annotations: { title: "Create Automation", readOnlyHint: false, destructiveHint: false },
               description:
-                "Create a new custom workflow from YAML definition. The YAML will be validated before deployment.",
+                "Create a new automation (a Windmill workflow) from a YAML definition. Pass the YAML document itself as a string, not a file path. It is validated server-side before deployment; on failure nothing is deployed and the errors are returned.",
               inputSchema: zodToJsonSchema(
                 customWorkflows.CreateCustomWorkflowSchema
               ),
             },
             {
               name: "update_custom_workflow",
-              annotations: { title: "Update Custom Workflow", readOnlyHint: false, destructiveHint: false },
+              annotations: { title: "Update Automation", readOnlyHint: false, destructiveHint: false },
               description:
-                "Update an existing custom workflow with new YAML. Only custom workflows (created via create_custom_workflow) can be updated.",
+                "Update an existing automation with new YAML. Only automations created via create_custom_workflow can be updated.",
               inputSchema: zodToJsonSchema(
                 customWorkflows.UpdateCustomWorkflowSchema
               ),
             },
             {
               name: "add_workflow_schedule",
-              annotations: { title: "Add Workflow Schedule", readOnlyHint: false, destructiveHint: false },
+              annotations: { title: "Add Automation Schedule", readOnlyHint: false, destructiveHint: false },
               description:
-                "Add a cron-based schedule to a workflow. The schedule will trigger the workflow automatically at the specified times.",
+                "Add a cron-based schedule to an automation so it runs automatically at the specified times.",
               inputSchema: zodToJsonSchema(
                 customWorkflows.AddWorkflowScheduleSchema
               ),
@@ -634,6 +632,20 @@ For complete schema: call radql_get_type_metadata with target data_type`,
               description:
                 "Get detailed information about a specific dashboard",
               inputSchema: zodToJsonSchema(dashboards.GetDashboardSchema),
+            },
+            {
+              name: "create_dashboard",
+              annotations: { title: "Create Dashboard", readOnlyHint: false, destructiveHint: false },
+              description:
+                "Create a dashboard for the account. Build `rows` from the widget templates (list_widget_templates / get_widget_template) so the visualization and query shapes are valid.",
+              inputSchema: zodToJsonSchema(dashboards.CreateDashboardSchema),
+            },
+            {
+              name: "update_dashboard",
+              annotations: { title: "Update Dashboard", readOnlyHint: false, destructiveHint: false },
+              description:
+                "Update an existing dashboard. Omitted fields are left unchanged, so a small edit (a title, one row) does not require resending the whole dashboard.",
+              inputSchema: zodToJsonSchema(dashboards.UpdateDashboardSchema),
             },
           ]
         : []),
@@ -1408,6 +1420,31 @@ For complete schema: call radql_get_type_metadata with target data_type`,
             const response = await dashboards.getDashboard(
               client,
               args.dashboard_id
+            );
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(response, null, 2) },
+              ],
+            };
+          }
+          case "create_dashboard": {
+            const args = dashboards.CreateDashboardSchema.parse(
+              request.params.arguments
+            );
+            const response = await dashboards.createDashboard(client, args);
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(response, null, 2) },
+              ],
+            };
+          }
+          case "update_dashboard": {
+            const { dashboard_id, ...changes } =
+              dashboards.UpdateDashboardSchema.parse(request.params.arguments);
+            const response = await dashboards.updateDashboard(
+              client,
+              dashboard_id,
+              changes
             );
             return {
               content: [

--- a/src/operations/dashboards.ts
+++ b/src/operations/dashboards.ts
@@ -134,3 +134,76 @@ export async function getDashboard(
     `/accounts/${client.getAccountId()}/dashboards/${dashboard_id}`
   );
 }
+
+// Schema for create_dashboard
+export const CreateDashboardSchema = z.object({
+  title: z.string().describe("Dashboard title shown in the UI"),
+  rows: z
+    .array(z.record(z.any()))
+    .describe(
+      "Dashboard layout: an ordered list of rows, each holding widgets. Build widgets from list_widget_templates / get_widget_template so the visualization and query shapes are valid."
+    ),
+  description: z.string().optional().describe("What the dashboard shows, and who it is for"),
+  tags: z.array(z.string()).optional().describe("Tags used to group and filter dashboards"),
+  visibility: z
+    .string()
+    .optional()
+    .describe("Dashboard visibility, e.g. 'private' or 'public'. Defaults to the account's default."),
+});
+
+// Schema for update_dashboard
+export const UpdateDashboardSchema = z.object({
+  dashboard_id: z.string().describe("ID of the dashboard to update"),
+  title: z.string().optional().describe("New title"),
+  rows: z
+    .array(z.record(z.any()))
+    .optional()
+    .describe(
+      "Replacement layout. `rows` is replaced wholesale, so when you change it send the full intended layout, not just the changed row. Omit it entirely to leave the layout untouched."
+    ),
+  description: z.string().optional().describe("New description"),
+  tags: z.array(z.string()).optional().describe("New tags"),
+  visibility: z.string().optional().describe("New visibility"),
+});
+
+/**
+ * Create a dashboard.
+ */
+export async function createDashboard(
+  client: RadSecurityClient,
+  args: {
+    title: string;
+    rows: Record<string, any>[];
+    description?: string;
+    tags?: string[];
+    visibility?: string;
+  }
+): Promise<any> {
+  return client.makeRequest(
+    `/accounts/${client.getAccountId()}/dashboards`,
+    {},
+    { method: "POST", body: args }
+  );
+}
+
+/**
+ * Update a dashboard. PATCH semantics: omitted fields are left untouched, so a small edit does
+ * not require resending the whole dashboard.
+ */
+export async function updateDashboard(
+  client: RadSecurityClient,
+  dashboard_id: string,
+  changes: {
+    title?: string;
+    rows?: Record<string, any>[];
+    description?: string;
+    tags?: string[];
+    visibility?: string;
+  }
+): Promise<any> {
+  return client.makeRequest(
+    `/accounts/${client.getAccountId()}/dashboards/${dashboard_id}`,
+    {},
+    { method: "PATCH", body: changes }
+  );
+}


### PR DESCRIPTION
## Summary

Three simplifications so a single general-purpose agent gets the full RAD toolset from one MCP connection, instead of needing a per-capability profile.

- **Removed `DISABLED_BY_DEFAULT_TOOLKITS`.** Every toolkit is enabled by default; narrowing is opt-in via `INCLUDE_TOOLKITS` / `EXCLUDE_TOOLKITS` or the `X-Rad-Toolkits` / `X-Rad-Exclude-Toolkits` headers. Write safety was never the toolkit list's job — `readonly` is enforced per tool (it filters the advertised list, and `CallTool` rejects anything not advertised), so a read-only caller stays read-only regardless of which toolkits load.
- **Folded automation authoring into the `workflows` toolkit.** `create_custom_workflow`, `update_custom_workflow` and `add_workflow_schedule` now ship alongside the read tools. The separate `custom_workflows` toolkit existed only to carry the disabled-by-default flag, so it is gone from `ToolkitType`.
- **Added `create_dashboard` (POST) and `update_dashboard` (PATCH).** `update_dashboard` takes a partial, so changing a title doesn't require resending every row. `rows` is still replaced wholesale when supplied, which the schema description says explicitly.
- **Terminology.** "Automation" is the product name users see; "workflow" is the underlying Windmill object the API and tool names use. Descriptions and titles now say automation, identifiers stay workflow, and the README states the mapping rather than leaving both words unexplained.

## Tool names are unchanged, deliberately

`create_custom_workflow` / `update_custom_workflow` keep their names even though their titles now read "Create/Update Automation". The names are a public contract: the web-app's automations builder detects a written workflow by matching the tool name, and onboarding provisioning does the same. Renaming them would silently break the builder — it fails closed with no error surfaced.

## Behaviour change worth flagging before merge

This makes `create_custom_workflow` (and the other two write tools) **reachable by every agent by default**, where previously they required an explicit `INCLUDE_TOOLKITS=custom_workflows`. That is the intent — it's what lets one agent handle both chat and automations — but it widens who can deploy a Windmill workflow.

It also raises the priority of the **human-approval interrupt on write tools**, already tracked in `AUTOMATIONS_V4_MIGRATION.md` §3.2. Until that lands, the mitigations are `X-Rad-Readonly: true` for any agent that shouldn't write, and `X-Rad-Exclude-Toolkits: workflows` to drop authoring specifically.

## Testing

`npm run build`, `npm run type-check` and `npm run lint` are clean. No test script exists in this repo. The dashboard endpoints (`POST /accounts/{acc}/dashboards`, `PATCH /accounts/{acc}/dashboards/{id}`) were confirmed against the live API — `PUT` returns 405, which is why update uses PATCH.