### PR TITLE
Stop echoing the workflow definition back from create/update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -414,7 +414,7 @@ async function newServer(
               name: "create_custom_workflow",
               annotations: { title: "Create Automation", readOnlyHint: false, destructiveHint: false },
               description:
-                "Create a new automation (a Windmill workflow) from a YAML definition. Pass the YAML document itself as a string, not a file path. It is validated server-side before deployment; on failure nothing is deployed and the errors are returned.",
+                "Create a new automation (a Windmill workflow) from a YAML definition. Pass the YAML document itself as a string, not a file path. It is validated server-side before deployment; on failure nothing is deployed and the errors are returned. Returns the new automation WITHOUT echoing the definition back — use `id` from the result when referring to it, and `get_workflow` if you need to read the definition.",
               inputSchema: zodToJsonSchema(
                 customWorkflows.CreateCustomWorkflowSchema
               ),
@@ -423,7 +423,7 @@ async function newServer(
               name: "update_custom_workflow",
               annotations: { title: "Update Automation", readOnlyHint: false, destructiveHint: false },
               description:
-                "Update an existing automation with new YAML. Only automations created via create_custom_workflow can be updated.",
+                "Update an existing automation with new YAML. Only automations created via create_custom_workflow can be updated. Returns the updated automation without echoing the definition back.",
               inputSchema: zodToJsonSchema(
                 customWorkflows.UpdateCustomWorkflowSchema
               ),

--- a/src/operations/custom-workflows.ts
+++ b/src/operations/custom-workflows.ts
@@ -27,6 +27,28 @@ export const AddWorkflowScheduleSchema = z.object({
 });
 
 /**
+ * Strip the echoed workflow definition from a create/update response.
+ *
+ * The API returns the whole stored workflow, and `flow` — the definition the caller just sent —
+ * is 94% of it (11,382 of 12,091 bytes on a measured deploy). Handing that back to an LLM costs
+ * ~3k tokens to tell it what it just wrote, and it is the only reason the result is large enough
+ * for the agent runtime to offload it to a file and replace it with a 500-char preview. That
+ * preview is what the web-app's automations builder then regexes for `"id"` — so today the
+ * workflow id survives purely because `id` happens to sort first in the response.
+ *
+ * Everything except `flow` is kept: the remaining fields total a few hundred bytes, and dropping
+ * only the echo keeps this a safe change for any other consumer.
+ *
+ * Read the definition back with `get_workflow` when it is actually needed.
+ */
+function withoutFlowDefinition<T>(response: T): T {
+  if (!response || typeof response !== "object" || Array.isArray(response)) return response;
+  const rest = { ...(response as Record<string, unknown>) };
+  delete rest.flow;
+  return rest as T;
+}
+
+/**
  * Create a custom workflow from YAML
  */
 export async function createCustomWorkflow(
@@ -49,7 +71,7 @@ export async function createCustomWorkflow(
     }
   );
 
-  return response;
+  return withoutFlowDefinition(response);
 }
 
 /**
@@ -76,7 +98,7 @@ export async function updateCustomWorkflow(
     }
   );
 
-  return response;
+  return withoutFlowDefinition(response);
 }
 
 /**


### PR DESCRIPTION
## Summary

`create_custom_workflow` / `update_custom_workflow` returned the whole stored workflow. Measured on a real deploy:

| field | bytes | share |
|---|---:|---:|
| `flow` | 11,382 | **94%** |
| metadata | 294 | 2% |
| id | 166 | 1% |
| everything else | ~102 | <1% |
| **total** | **12,091** | |

`flow` is the definition **the caller just sent**. Handing it back to an LLM costs ~3k tokens to tell it what it just wrote.

## The part that's actually a bug

That echo is the only reason the result crosses the agent runtime's 4,000-char offload threshold. Over it, the result is written to a sandbox file and replaced with a **500-char preview**.

The web-app's automations builder learns a workflow was deployed by regexing the tool **result** for `"id"`. So today the id survives purely because `id` happens to sort first inside those 500 chars. Reorder the response and the builder silently stops seeing new automations — the workflow deploys fine, but there's no version in the sidebar, no console error, and the blocking overlay never clears.

Dropping `flow` takes the response to a few hundred bytes, comfortably under the threshold, so the builder gets real JSON instead of a truncated preview.

## Scope

Only `flow` is stripped — every other field is preserved, so this stays safe for any other consumer. Read the definition back with `get_workflow` when it's actually needed; both tool descriptions now say so.

## Testing

`npm run build`, `npx tsc --noEmit` and `npm run lint` are clean (no test script in this repo). The helper was exercised directly against a representative payload: 14,550 → 129 bytes, `id` preserved, result under the offload threshold, and non-object inputs (`null`, `undefined`, strings, numbers, arrays) pass through untouched.

## Related

- `ai-agents` adds a `NEVER_OFFLOAD` backstop so these results are never previewed even if a future response grows past the threshold again.
- rad-security/web-app#476 fixes the matching of the namespaced tool name (`rad__create_custom_workflow`), which is the other half of why the builder went blind on rad_v4.