### PR TITLE
Drop the dashboard tags parameter the API silently ignores

### DIFF
--- a/src/operations/dashboards.ts
+++ b/src/operations/dashboards.ts
@@ -144,12 +144,17 @@ export const CreateDashboardSchema = z.object({
       "Dashboard layout: an ordered list of rows, each holding widgets. Build widgets from list_widget_templates / get_widget_template so the visualization and query shapes are valid."
     ),
   description: z.string().optional().describe("What the dashboard shows, and who it is for"),
-  tags: z.array(z.string()).optional().describe("Tags used to group and filter dashboards"),
   visibility: z
     .string()
     .optional()
     .describe("Dashboard visibility, e.g. 'private' or 'public'. Defaults to the account's default."),
 });
+
+// No `tags` parameter, deliberately. The dashboards API returns a `tags` field, but it drops the
+// value on both POST and PATCH — verified against sbx: creating with ["alpha","beta"] and then
+// patching ["gamma"] both read back as []. Advertising a parameter that silently does nothing is
+// worse than not having it: the model spends tokens choosing tags and believes it applied them.
+// Re-add on both schemas if the API starts honouring it.
 
 // Schema for update_dashboard
 export const UpdateDashboardSchema = z.object({
@@ -162,7 +167,6 @@ export const UpdateDashboardSchema = z.object({
       "Replacement layout. `rows` is replaced wholesale, so when you change it send the full intended layout, not just the changed row. Omit it entirely to leave the layout untouched."
     ),
   description: z.string().optional().describe("New description"),
-  tags: z.array(z.string()).optional().describe("New tags"),
   visibility: z.string().optional().describe("New visibility"),
 });
 
@@ -175,7 +179,6 @@ export async function createDashboard(
     title: string;
     rows: Record<string, any>[];
     description?: string;
-    tags?: string[];
     visibility?: string;
   }
 ): Promise<any> {
@@ -197,7 +200,6 @@ export async function updateDashboard(
     title?: string;
     rows?: Record<string, any>[];
     description?: string;
-    tags?: string[];
     visibility?: string;
   }
 ): Promise<any> {


### PR DESCRIPTION
## Summary

Tested `create_dashboard` / `update_dashboard` end to end against sbx (v0.0.41, the deployed hosted server) over a real MCP session. Both work — with one bug.

**`tags` is a guaranteed no-op.** Creating with `["alpha","beta"]` and then patching `["gamma"]` both read back as `[]`. The dashboards API returns a `tags` field but drops the value on POST and PATCH alike, so the parameter could never do anything.

That's worse than not having it: the model spends tokens deciding on tags, tells the user it tagged the dashboard, and nothing is tagged. Removed from both schemas and both signatures, with the evidence recorded in a comment so it isn't re-added by someone reading the response shape.

`visibility` is kept — it round-trips correctly (`private` in, `private` out).

## What the test confirmed works

```
initialize              -> RAD Security MCP Server 0.0.41
tools/list              -> create_dashboard, update_dashboard advertised (52 tools total)
create_dashboard        -> persisted; id returned; rows + widgets intact on read-back
update_dashboard        -> sent ONLY {title}; description, tags and rows unchanged
```

That last line is the important one: it confirms the PATCH semantics the tool description promises — "omitted fields are left unchanged, so a small edit does not require resending the whole dashboard".

Both test dashboards were deleted afterwards (`DELETE` → 204); the account is clean.

## Note

This is the first end-to-end exercise of these tools. They were added in #49 with the API shape derived from probing endpoints (`POST` works, `PUT` → 405, hence PATCH), not from a successful round-trip — so this closes that gap.