### PR TITLE
Serve /mcp statelessly so the deployment can scale past one replica

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,8 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import cors from "cors";
-import { randomUUID } from "node:crypto";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { z } from "zod";
 import {
@@ -1684,102 +1682,79 @@ async function main() {
         res.status(200).json({ status: "ok" });
       });
 
-      // Map to store transports by session ID
-      const transports: { [sessionId: string]: StreamableHTTPServerTransport } =
-        {};
-
-      // Handle POST requests for client-to-server communication
+      // Stateless: a transport and server are built per request and torn down with it.
+      //
+      // The previous shape kept `transports[sessionId]` in process memory, so a follow-up request
+      // that landed on another replica found nothing and failed. That pinned this deployment to a
+      // single pod, which means a node drain takes the hosted MCP server down for every agent
+      // using it. Nothing here is worth keeping between requests: credentials arrive per request
+      // (MCP_AUTH_MODE=header) and so do the toolkit filters, so every call already describes
+      // itself. Statelessness lets any request land on any replica behind a plain round-robin
+      // service, with no sticky sessions and no shared store.
+      //
+      // This is the SDK's documented stateless mode (`sessionIdGenerator: undefined`), and it is
+      // also the shape the 2026-07-28 MCP spec assumes now that protocol-level sessions are gone.
       app.post("/mcp", async (req, res) => {
-        // Check for existing session ID
-        const sessionId = req.headers["mcp-session-id"] as string | undefined;
-        let transport: StreamableHTTPServerTransport;
-
-        if (sessionId && transports[sessionId]) {
-          // Reuse existing transport
-          transport = transports[sessionId];
-        } else if (!sessionId && isInitializeRequest(req.body)) {
-          // New session: resolve credentials before creating the transport so an
-          // unauthenticated caller is rejected with 401 rather than a live session.
-          let client: RadSecurityClient;
-          try {
-            client = clientForRequest(req, authMode);
-          } catch (err) {
-            if (err instanceof CredentialError) {
-              res
-                .status(401)
-                .set(
-                  "WWW-Authenticate",
-                  `Bearer error="invalid_token", error_description="${err.message}"`
-                )
-                .json({
-                  jsonrpc: "2.0",
-                  error: { code: -32001, message: err.message },
-                  id: null,
-                });
-              return;
-            }
-            throw err;
+        // Resolve credentials first so an unauthenticated caller gets a 401 rather than a
+        // half-built server.
+        let client: RadSecurityClient;
+        try {
+          client = clientForRequest(req, authMode);
+        } catch (err) {
+          if (err instanceof CredentialError) {
+            res
+              .status(401)
+              .set(
+                "WWW-Authenticate",
+                `Bearer error="invalid_token", error_description="${err.message}"`
+              )
+              .json({
+                jsonrpc: "2.0",
+                error: { code: -32001, message: err.message },
+                id: null,
+              });
+            return;
           }
-
-          // New initialization request
-          transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: () => randomUUID(),
-            onsessioninitialized: (sessionId) => {
-              // Store the transport by session ID
-              transports[sessionId] = transport;
-            },
-          });
-
-          // Clean up transport when closed
-          transport.onclose = () => {
-            if (transport.sessionId) {
-              delete transports[transport.sessionId];
-            }
-          };
-          const server = await newServer(
-            client,
-            toolkitFiltersForRequest(req)
-          );
-
-          // Connect to the MCP server
-          await server.connect(transport);
-        } else {
-          // Invalid request
-          res.status(400).json({
-            jsonrpc: "2.0",
-            error: {
-              code: -32000,
-              message: "Bad Request: No valid session ID provided",
-            },
-            id: null,
-          });
-          return;
+          throw err;
         }
 
-        // Handle the request
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+        });
+        const server = await newServer(client, toolkitFiltersForRequest(req));
+
+        // Tear both down when the response ends, however it ends. Without this every request
+        // leaks a Server and its transport — which matters far more now that one is built per
+        // call rather than per session.
+        res.on("close", () => {
+          void transport.close();
+          void server.close();
+        });
+
+        await server.connect(transport);
         await transport.handleRequest(req, res, req.body);
       });
 
-      // Reusable handler for GET and DELETE requests
-      const handleSessionRequest = async (
-        req: express.Request,
-        res: express.Response
-      ) => {
-        const sessionId = req.headers["mcp-session-id"] as string | undefined;
-        if (!sessionId || !transports[sessionId]) {
-          res.status(400).send("Invalid or missing session ID");
-          return;
-        }
-
-        const transport = transports[sessionId];
-        await transport.handleRequest(req, res);
+      // GET opens a server-to-client SSE stream and DELETE terminates a session. Both are session
+      // concepts and there are no sessions here, so answer with 405 and a reason rather than a
+      // 400 about a missing session id that can never be satisfied.
+      const noSessionEndpoint = (_req: express.Request, res: express.Response) => {
+        res
+          .status(405)
+          .set("Allow", "POST")
+          .json({
+            jsonrpc: "2.0",
+            error: {
+              code: -32000,
+              message:
+                "This server is stateless: no sessions and no server-initiated stream. Send requests as POST /mcp.",
+            },
+            id: null,
+          });
       };
 
-      // Handle GET requests for server-to-client notifications via SSE
-      app.get("/mcp", handleSessionRequest);
-
-      // Handle DELETE requests for session termination
-      app.delete("/mcp", handleSessionRequest);
+      app.get("/mcp", noSessionEndpoint);
+      app.delete("/mcp", noSessionEndpoint);
 
       const port = process.env.PORT || 3000;
       app.listen(port, () => {


### PR DESCRIPTION
## Why it's stuck at one replica

```ts
const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
```

An **in-process map**. `initialize` mints a session id and stores the transport there; every later request does `transports[sessionId]`. Land on a different replica and that map is empty. At N replicas roughly (N-1)/N of follow-up requests fail unless you add sticky sessions.

This is an **availability** constraint, not a capacity one — the prd pod idles well inside its 500m/1Gi limits, 3 days uptime, zero restarts. But at one replica a node drain takes the hosted MCP server down for every agent using it.

## The change

Nothing was worth keeping between requests. Credentials arrive per request (`MCP_AUTH_MODE=header`) and so do the toolkit filters, so every call already describes itself.

The handler now builds a transport and server per request using the SDK's documented stateless mode (`sessionIdGenerator: undefined`) and tears both down on response close. Any request can land on any replica behind a plain round-robin service — no sticky sessions, no shared store.

`GET` and `DELETE` on `/mcp` are session concepts (a server-initiated stream, and session teardown). They now answer **405 with an explanation** instead of a 400 about a missing session id that can never be satisfied.

## Verified against sbx with a local build

| check | result |
|---|---|
| `tools/list` with **no initialize, no session id** | 52 tools returned |
| `Mcp-Session-Id` issued? | no — only the CORS `Access-Control-Expose-Headers` declaration |
| **existing clients** (`initialize` → `tools/call`) | still work; follow-up needs no session id |
| `GET /mcp` | 405 with the explanatory body |

That third row is the one that matters for rollout: this is how rad-bot-ts and Claude Desktop connect, and they are unaffected. `initialize` simply becomes a no-op handshake.

## Memory — please look at this before prd

Building a Server per request costs something. Over **240 sequential** `tools/list` calls RSS went **79MB → 120MB**, with file descriptors flat at 21, no errors, and no drop during a 25s idle. Growth decelerated after the first burst, which is consistent with lazy V8 heap growth rather than a leak — but 240 requests is not enough to prove it either way, and I would rather say so than assert it.

Soak it on sbx before prd. The 1Gi limit leaves headroom and Kubernetes restarts the pod if I am wrong.

## Relation to the 2026-07-28 spec

That spec retires protocol-level sessions entirely — no `initialize`, no `Mcp-Session-Id`, identity and capabilities in `_meta` per request — precisely so any request can hit any instance. This change puts us in that shape now, using the SDK we already have, so adopting the spec later is an SDK upgrade rather than a rewrite. Its other wins (`Mcp-Method`/`Mcp-Name` header routing, `ttlMs`/`cacheScope` on list responses) need client-side support too, so they are a separate conversation.

## Scope

The legacy SSE transport branch is untouched.

Replica count is a GitOps change and is **not** in this PR — bump it after this deploys and soaks.